### PR TITLE
QueryProxy #as and #with

### DIFF
--- a/lib/neo4j/active_node/dependent/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/dependent/query_proxy_methods.rb
@@ -37,7 +37,7 @@ module Neo4j
 
         def unique_nodes_query(association, self_identifer, other_node, other_rel)
           query.with(identity).proxy_as_optional(source_object.class, self_identifer)
-            .send(association.name, other_node, other_rel)
+            .send(association.name).as(other_node, other_rel)
             .query
             .with(other_node)
             .match("()#{association.arrow_cypher(:orphan_rel)}(#{other_node})")

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -404,6 +404,10 @@ module Neo4j::ActiveNode
       def define_has_one_methods(name)
         define_has_one_getter(name)
 
+        define_method("#{name}_proxy") do
+          association_proxy(name)
+        end
+
         define_has_one_setter(name)
 
         define_has_one_id_methods(name)

--- a/lib/neo4j/active_node/query.rb
+++ b/lib/neo4j/active_node/query.rb
@@ -28,8 +28,8 @@ module Neo4j
       #
       # @param [String, Symbol] node_var The identifier to use within the QueryProxy object
       # @return [Neo4j::ActiveNode::Query::QueryProxy]
-      def as(node_var)
-        self.class.query_proxy(node: node_var, source_object: self).match_to(self)
+      def as(node_var, rel_var = nil, options = {})
+        self.class.query_proxy({node: node_var, rel: rel_var, source_object: self}.merge(options)).match_to(self)
       end
 
       module ClassMethods
@@ -67,8 +67,12 @@ module Neo4j
         #
         # @param [String, Symbol] node_var A string or symbol to use as the starting identifier.
         # @return [Neo4j::ActiveNode::Query::QueryProxy]
-        def as(node_var)
-          query_proxy(node: node_var, context: self.name)
+        def as(node_var, rel_var = nil, options = {})
+          query_proxy({node: node_var, rel: rel_var, context: self.name}.merge(options))
+        end
+
+        def with(options)
+          as(nil, nil, options)
         end
       end
     end

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -220,12 +220,18 @@ module Neo4j
 
         delegate :to_ary, to: :to_a
 
+        def as(node_var, rel_var = nil, options = {})
+          new_link(node_var, rel_var, options)
+        end
+
         # QueryProxy objects act as a representation of a model at the class level so we pass through calls
         # This allows us to define class functions for reusable query chaining or for end-of-query aggregation/summarizing
         def method_missing(method_name, *args, &block)
           if @model && @model.respond_to?(method_name)
             scoping { @model.public_send(method_name, *args, &block) }
           else
+            require 'pry'
+            binding.pry
             super
           end
         end
@@ -240,10 +246,14 @@ module Neo4j
 
         attr_reader :context
 
-        def new_link(node_var = nil)
+        def new_link(node_var = nil, rel_var = nil, options = {})
           self.clone.tap do |new_query_proxy|
             new_query_proxy.instance_variable_set('@result_cache', nil)
             new_query_proxy.instance_variable_set('@node_var', node_var) if node_var
+            new_query_proxy.instance_variable_set('@rel_var', rel_var) if rel_var
+            new_query_proxy.instance_variable_set('@optional', options[:optional]) if options.key?(:optional)
+            new_query_proxy.instance_variable_set('@rel_length', options[:rel_length]) if options.key?(:rel_length)
+            new_query_proxy.instance_variable_set('@association_labels', options[:labels]) if options.key?(:labels)
           end
         end
 

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -232,8 +232,6 @@ module Neo4j
           if @model && @model.respond_to?(method_name)
             scoping { @model.public_send(method_name, *args, &block) }
           else
-            require 'pry'
-            binding.pry
             super
           end
         end

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -44,8 +44,6 @@ module Neo4j
 
           instance_vars_from_options!(options)
 
-          @match_type = @optional ? :optional_match : :match
-
           @rel_var = options[:rel] || _rel_chain_var
 
           @chain = []
@@ -103,7 +101,7 @@ module Neo4j
         def base_query(var, with_labels = true)
           if @association
             chain_var = _association_chain_var
-            (_association_query_start(chain_var) & _query).break.send(@match_type,
+            (_association_query_start(chain_var) & _query).break.send(match_type,
                                                                       "#{chain_var}#{_association_arrow}(#{var}#{_model_label_string})")
           else
             starting_query ? starting_query : _query_model_as(var, with_labels)
@@ -224,6 +222,10 @@ module Neo4j
           new_link(node_var, rel_var, options)
         end
 
+        def with(options)
+          as(nil, nil, options)
+        end
+
         # QueryProxy objects act as a representation of a model at the class level so we pass through calls
         # This allows us to define class functions for reusable query chaining or for end-of-query aggregation/summarizing
         def method_missing(method_name, *args, &block)
@@ -242,6 +244,10 @@ module Neo4j
 
         def optional?
           @optional == true
+        end
+
+        def match_type
+          @optional ? :optional_match : :match
         end
 
         attr_reader :context
@@ -269,7 +275,7 @@ module Neo4j
         end
 
         def _query_model_as(var, with_labels = true)
-          _query.break.send(@match_type, _match_arg(var, with_labels))
+          _query.break.send(match_type, _match_arg(var, with_labels))
         end
 
         # @param [String, Symbol] var The Cypher identifier to use within the match string

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -398,34 +398,34 @@ describe 'has_many' do
     context 'as Symbol' do
       context ':any' do
         it 'returns any direct or indirect related node' do
-          expect(node.knows(:n, :r, rel_length: :any).to_a).to match_array([friend1, friend2])
+          expect(node.knows.as(:n, :r, rel_length: :any).to_a).to match_array([friend1, friend2])
         end
       end
     end
 
     context 'as Fixnum' do
       it 'returns related nodes at exactly `length` hops from start node' do
-        expect(node.knows(:n, :r, rel_length: 1).to_a).to match_array([friend1])
-        expect(node.knows(:n, :r, rel_length: 2).to_a).to match_array([friend2])
+        expect(node.knows.as(:n, :r, rel_length: 1).to_a).to match_array([friend1])
+        expect(node.knows.as(:n, :r, rel_length: 2).to_a).to match_array([friend2])
       end
     end
 
     context 'as Range' do
       it 'returns related nodes within given range of hops from start node' do
-        expect(node.knows(nil, nil, rel_length: (0..3)).to_a).to match_array([node, friend1, friend2])
-        expect(node.knows(nil, nil, rel_length: (1..2)).to_a).to match_array([friend1, friend2])
-        expect(node.knows(nil, nil, rel_length: (2..5)).to_a).to match_array([friend2])
+        expect(node.knows.with(rel_length: (0..3)).to_a).to match_array([node, friend1, friend2])
+        expect(node.knows.with(rel_length: (1..2)).to_a).to match_array([friend1, friend2])
+        expect(node.knows.with(rel_length: (2..5)).to_a).to match_array([friend2])
       end
     end
 
     context 'as Hash' do
       it 'returns related nodes within given range specified by :min/:max options' do
-        expect(node.knows(:n, :r, rel_length: {min: 0, max: 3}).to_a).to match_array([node, friend1, friend2])
+        expect(node.knows.as(:n, :r, rel_length: {min: 0, max: 3}).to_a).to match_array([node, friend1, friend2])
       end
 
       it 'accepts missing :min OR :max as denoting open-ended ranges' do
-        expect(node.knows(:n, :r, rel_length: {min: 1}).to_a).to match_array([friend1, friend2])
-        expect(node.knows(:n, :r, rel_length: {max: 1}).to_a).to match_array([friend1])
+        expect(node.knows.as(:n, :r, rel_length: {min: 1}).to_a).to match_array([friend1, friend2])
+        expect(node.knows.as(:n, :r, rel_length: {max: 1}).to_a).to match_array([friend1])
       end
     end
   end
@@ -437,7 +437,7 @@ describe 'has_many' do
     end
 
     it 'allows passing only a hash of options when naming node/rel is not needed' do
-      expect(node.knows(rel_length: :any).to_a).to match_array([friend1, friend2])
+      expect(node.knows.with(rel_length: :any).to_a).to match_array([friend1, friend2])
     end
   end
 

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -157,24 +157,27 @@ describe 'has_one' do
       end
 
       it 'finds the chain of command' do
-        employee.manager.as(:p, :r, rel_length: {min: 0}).to_a.should match_array([employee, manager, big_boss])
+        employee.manager_proxy.with(rel_length: {min: 0}).to_a.should match_array([employee, manager, big_boss])
       end
 
       it "finds the employee's superiors" do
-        employee.manager.as(:p, :r, rel_length: :any).to_a.should match_array([manager, big_boss])
+        employee.manager_proxy.with(rel_length: :any).to_a.should match_array([manager, big_boss])
       end
 
       it 'finds a specific superior in the chain of command' do
-        employee.manager.as(:p, :r, rel_length: 1).should eq(manager)
-        employee.manager.as(:p, :r, rel_length: 2).should eq(big_boss)
+        employee.manager(rel_length: 1).should eq(manager)
+        employee.manager(rel_length: 1).should eq(manager)
+
+        employee.manager_proxy.with(rel_length: 1).first.should eq(manager)
+        employee.manager_proxy.with(rel_length: 2).first.should eq(big_boss)
       end
 
       it 'finds parts of the chain of command using a range' do
-        employee.manager.as(:p, :r, rel_length: (0..1)).to_a.should match_array([employee, manager])
+        employee.manager_proxy.with(rel_length: (0..1)).to_a.should match_array([employee, manager])
       end
 
       it 'finds parts of the chain of command using a hash' do
-        employee.manager.as(:p, :r, rel_length: {min: 1, max: 3}).to_a.should match_array([manager, big_boss])
+        employee.manager_proxy.with(rel_length: {min: 1, max: 3}).to_a.should match_array([manager, big_boss])
       end
     end
   end
@@ -192,7 +195,8 @@ describe 'has_one' do
 
     it 'allows passing only a hash of options when naming node/rel is not needed' do
       manager.subordinates << employee
-      employee.manager.with(rel_length: 1).should eq(manager)
+      employee.manager(rel_length: 1).should eq(manager)
+      employee.manager_proxy.with(rel_length: 1).first.should eq(manager)
     end
   end
 

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -157,24 +157,24 @@ describe 'has_one' do
       end
 
       it 'finds the chain of command' do
-        employee.manager(:p, :r, rel_length: {min: 0}).to_a.should match_array([employee, manager, big_boss])
+        employee.manager.as(:p, :r, rel_length: {min: 0}).to_a.should match_array([employee, manager, big_boss])
       end
 
       it "finds the employee's superiors" do
-        employee.manager(:p, :r, rel_length: :any).to_a.should match_array([manager, big_boss])
+        employee.manager.as(:p, :r, rel_length: :any).to_a.should match_array([manager, big_boss])
       end
 
       it 'finds a specific superior in the chain of command' do
-        employee.manager(:p, :r, rel_length: 1).should eq(manager)
-        employee.manager(:p, :r, rel_length: 2).should eq(big_boss)
+        employee.manager.as(:p, :r, rel_length: 1).should eq(manager)
+        employee.manager.as(:p, :r, rel_length: 2).should eq(big_boss)
       end
 
       it 'finds parts of the chain of command using a range' do
-        employee.manager(:p, :r, rel_length: (0..1)).to_a.should match_array([employee, manager])
+        employee.manager.as(:p, :r, rel_length: (0..1)).to_a.should match_array([employee, manager])
       end
 
       it 'finds parts of the chain of command using a hash' do
-        employee.manager(:p, :r, rel_length: {min: 1, max: 3}).to_a.should match_array([manager, big_boss])
+        employee.manager.as(:p, :r, rel_length: {min: 1, max: 3}).to_a.should match_array([manager, big_boss])
       end
     end
   end
@@ -192,7 +192,7 @@ describe 'has_one' do
 
     it 'allows passing only a hash of options when naming node/rel is not needed' do
       manager.subordinates << employee
-      employee.manager(rel_length: 1).should eq(manager)
+      employee.manager.with(rel_length: 1).should eq(manager)
     end
   end
 

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -505,7 +505,7 @@ describe 'query_proxy_methods' do
     end
 
     it 'starts a new optional match' do
-      result = @lauren.lessons.as(:l).optional.as(:teachers, :t).where(age: 40).query.order(l: :name).pluck('distinct l, t')
+      result = @lauren.lessons.as(:l).teachers.as(:t).with(optional: true).where(age: 40).query.order(l: :name).pluck('distinct l, t')
 
       expect(result).to eq [[@math, @johnson],
                             [@science, nil]]

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -303,14 +303,14 @@ describe 'query_proxy_methods' do
       end
 
       it 'can target a specific identifier' do
-        @tom.lessons(:l).teachers.where(name: 'Mr Adams').delete_all(:l)
+        @tom.lessons.as(:l).teachers.where(name: 'Mr Adams').delete_all(:l)
         expect(@tom.lessons.include?(@math)).to be_falsey
         expect(@math.exist?).to be false
         expect(@tom.lessons.include?(@science)).to be_truthy
       end
 
       it 'can target relationships' do
-        @tom.lessons(:l, :r).teachers.where(name: 'Mr Adams').delete_all(:r)
+        @tom.lessons.as(:l, :r).teachers.where(name: 'Mr Adams').delete_all(:r)
         expect(@tom.lessons.include?(@math)).to be_falsey
         expect(@math).to be_persisted
       end
@@ -418,7 +418,7 @@ describe 'query_proxy_methods' do
         end
 
         it 'works with a chain starting with `all`' do
-          expect(Student.all.match_to(jimmy).lessons(:l).match_to(math).teachers.where(age: 40).first).to eq mr_jones
+          expect(Student.all.match_to(jimmy).lessons.as(:l).match_to(math).teachers.where(age: 40).first).to eq mr_jones
         end
       end
     end
@@ -505,7 +505,7 @@ describe 'query_proxy_methods' do
     end
 
     it 'starts a new optional match' do
-      result = @lauren.lessons(:l).optional(:teachers, :t).where(age: 40).query.order(l: :name).pluck('distinct l, t')
+      result = @lauren.lessons.as(:l).optional.as(:teachers, :t).where(age: 40).query.order(l: :name).pluck('distinct l, t')
 
       expect(result).to eq [[@math, @johnson],
                             [@science, nil]]


### PR DESCRIPTION
Proposed alternative/replacement for association arguments.  Still have some rubocop fixes.

Looking for discussion on this gist as well: https://gist.github.com/cheerfulstoic/3098872af7db8632c792
