### PR TITLE
Add: bang setters for associations

### DIFF
--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -9,6 +9,9 @@ module Neo4j
         include Neo4j::ActiveNode::Dependent::AssociationMethods
         include Neo4j::ActiveNode::HasN::AssociationCypherMethods
 
+        # Used when a bang association method (e.g. `person.add_job!`) fails
+        class PersistanceError < Neo4j::Error; end
+
         attr_reader :type, :name, :relationship, :direction, :dependent, :model_class
 
         def initialize(type, direction, name, options = {type: nil})
@@ -139,8 +142,8 @@ module Neo4j
           unique? ? :create_unique : :create
         end
 
-        def _create_relationship(start_object, node_or_nodes, properties)
-          RelFactory.create(start_object, node_or_nodes, properties, self)
+        def _create_relationship(start_object, node_or_nodes, properties, verify=false)
+          RelFactory.create(start_object, node_or_nodes, properties, self, verify)
         end
 
         def relationship_class?

--- a/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
@@ -48,12 +48,12 @@ module Neo4j
 
         # Deletes the relationships between all nodes for the last step in the QueryProxy chain and replaces them with relationships to the given nodes.
         # Executed in the database, callbacks will not be run.
-        def replace_with(node_or_nodes)
+        def replace_with(node_or_nodes, options: {})
           nodes = Array(node_or_nodes)
 
           self.delete_all_rels
           nodes.map do |node|
-            node if _create_relation_or_defer(node)
+            node if _create_relation_or_defer(node, verify: options[:verify])
           end.compact
           # nodes.each { |node| self << node }
         end


### PR DESCRIPTION
This PR adds bang setters for simple (non-ActiveRel) associations which raise an error if the association fails to persist (without an extra DB call). In my testing, creating an association with `ActiveRel` objects using either `.create!` or `.save!` already raises an error if it fails to persist.

```
person = Person.create
owner = Owner.create

Neo4j::ActiveBase.query("
  MATCH (n:`Person` {uuid: '#{person.id}'})
  DELETE n
")

owner.set_person! person
#=> Neo4j::ActiveNode::HasN::Association::PersistanceError: It appears the relation failed to persist in the database
```

All the tests are passing, but I haven't added any new tests yet. Implementing this ended up being pretty confusing and touching a lot of stuff, so I wanted to run it by you first. The implementation, while working, feels pretty ugly. Though it could be, in part, a result of how complicated the association logic is.

has_one associations now have:
* `object.set_#{association}!`

has_many associations now have:
* `object.set_#{associations}!`
* `object.add_#{association}!`
