### PR TITLE
Fix issue in association_proxy with == objects

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -221,7 +221,7 @@ module Neo4j::ActiveNode
 
             object.association_proxy_cache[hash] = proxy
 
-            (self == object ? proxy : proxy_to_return)
+            (self.neo_id == object.neo_id ? proxy : proxy_to_return)
           end
         else
           fresh_association_proxy(name, options)


### PR DESCRIPTION
 * rename `hash` variable to `proxy_hash_key`
 * rename `cache` variable to `association_query_results`
 * create proc on its own line, with simpler code
 * instead of using inject and complicating things, use each +
 self.association_proxy_cache[proxy_hash_key]. This also means that
 things won't go wrong if 2 objects in the query are == to each other
 but have different query results

Fixes #1529

This pull introduces/changes:
 * edits association_proxy method in HasN and makes it a bit clearer, and fixes #1529
 * see commit message for more detailed breakdown

Unfortunately, I'm not really sure how I could add a test for this issue in the repo. With some guidance I may be able to add one. The key would be making at least 3 database objects, 2 of which are == (see the pseudo-code in #1529)



