### PR TITLE
Fix for with_associations eager loading issue with relationship on same model

### DIFF
--- a/lib/active_graph/node/query/query_proxy_eager_loading.rb
+++ b/lib/active_graph/node/query/query_proxy_eager_loading.rb
@@ -16,7 +16,7 @@ module ActiveGraph
           @_cache = IdentityMap.new
           build_query
             .map do |record, eager_data|
-            cache_and_init(record, with_associations_tree)
+            record = cache_and_init(record, with_associations_tree)
             eager_data.zip(with_associations_tree.paths.map(&:last)).each do |eager_records, element|
               eager_records.first.zip(eager_records.last).each do |eager_record|
                 add_to_cache(*eager_record, element)

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -11,6 +11,7 @@ describe 'Association Proxy' do
         has_many :in, :exams, model_class: :Exam, origin: :students
         has_one :out, :favorite_lesson, type: nil, model_class: :Lesson
         has_many :out, :homework, type: :HOMEWORK, model_class: %w[Lesson Exam]
+        has_many :out, :friends, type: :friend, model_class: :Student
       end
 
       stub_relationship_class('LessonEnrollment') do
@@ -41,6 +42,8 @@ describe 'Association Proxy' do
     let(:math_exam) { Exam.create(name: 'Math Exam') }
     let(:science_exam) { Exam.create(name: 'Science Exam') }
     let(:science_exam2) { Exam.create(name: 'Science Exam 2') }
+    let(:leszek) { Student.create(name: 'Leszek', friends: [lukasz]) }
+    let(:lukasz) { Student.create(name: 'Lukasz') }
 
     before do
       [math, science].each { |lesson| billy.lessons << lesson }
@@ -49,6 +52,17 @@ describe 'Association Proxy' do
       science.exams_given << science_exam
       science.exams_given << science_exam2
       billy.favorite_lesson = math
+    end
+
+    context 'self referencing relationships' do
+      before { leszek }
+      it 'fire only one query' do
+        expect_queries(1) do
+          Student.all.with_associations(:friends).each do |student|
+            student.friends.to_a
+          end
+        end
+      end
     end
 
     it 'allows associations to respond to to_ary' do

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -42,8 +42,8 @@ describe 'Association Proxy' do
     let(:math_exam) { Exam.create(name: 'Math Exam') }
     let(:science_exam) { Exam.create(name: 'Science Exam') }
     let(:science_exam2) { Exam.create(name: 'Science Exam 2') }
-    let(:leszek) { Student.create(name: 'Leszek', friends: [lukasz]) }
-    let(:lukasz) { Student.create(name: 'Lukasz') }
+    let(:leszek) { Student.create(name: 'Leszek', friends: [zinto]) }
+    let(:zinto) { Student.create(name: 'Zinto') }
 
     before do
       [math, science].each { |lesson| billy.lessons << lesson }
@@ -57,8 +57,9 @@ describe 'Association Proxy' do
     context 'self referencing relationships' do
       before { leszek }
       it 'fire only one query' do
+        ActiveGraph::Base.subscribe_to_query(&method(:puts))
         expect_queries(1) do
-          Student.all.with_associations(:friends).each do |student|
+          Student.all.order(:name).with_associations(:friends).each do |student|
             student.friends.to_a
           end
         end


### PR DESCRIPTION
In a case where association is on the same model where it is defined and we eagerload such relationship with `with_associations`, we are getting extra queries fired rather than one.


