### PR TITLE
Separate transactions for schema load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.6.2] FIXME
+
+## Fixes
+
+- Perform separate tranactions around schema-load and migrations-update
+  to allow the seabolt driver to load schemas (#1599)
+
 ## [9.6.1] 2019-12-18
 
 ## Fixed

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -102,7 +102,8 @@ COMMENT
 
         Neo4j::ActiveBase.run_transaction do
           Neo4j::Migrations::Schema.synchronize_schema_data(Neo4j::ActiveBase.current_session, schema_data, args[:remove_missing])
-
+        end
+        Neo4j::ActiveBase.run_transaction do
           runner = Neo4j::Migrations::Runner.new
           runner.mark_versions_as_complete(schema_data[:versions]) # Run in test mode?
         end

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -95,11 +95,8 @@ COMMENT
         require 'neo4j/migrations/schema'
 
         args.with_defaults(remove_missing: false)
-
         schema_data = YAML.safe_load(File.read(SCHEMA_YAML_PATH), [Symbol])
-
         Neo4j::Core::CypherSession::Adaptors::Base.subscribe_to_query(&method(:puts))
-
         Neo4j::ActiveBase.run_transaction do
           Neo4j::Migrations::Schema.synchronize_schema_data(Neo4j::ActiveBase.current_session, schema_data, args[:remove_missing])
         end


### PR DESCRIPTION
Fixes #1599 

This pull introduces/changes:
 * Separate migrations for schema-load and migrations update, this to allow the seabolt driver to load schemas.



