### PR TITLE
Allow specify column(s) to touch

### DIFF
--- a/lib/active_graph/shared/callbacks.rb
+++ b/lib/active_graph/shared/callbacks.rb
@@ -30,7 +30,7 @@ module ActiveGraph
         raise
       end
 
-      def touch #:nodoc:
+      def touch(*) #:nodoc:
         run_callbacks(:touch) { super }
       end
 

--- a/lib/active_graph/shared/persistence.rb
+++ b/lib/active_graph/shared/persistence.rb
@@ -104,10 +104,17 @@ module ActiveGraph::Shared
       end
     end
 
-    def touch
+    def touch(*names)
       fail 'Cannot touch on a new record object' unless persisted?
-      update_attribute!(:updated_at, Time.now) if respond_to?(:updated_at=)
-    end
+      attributes = [:updated_at].concat(names)
+      current_time = Time.now
+      changes = {}
+      attributes.each do |column|
+        column = column.to_s       
+        changes[column] = write_attribute(column, current_time) if respond_to?((column + '=').to_sym)
+      end
+      save!
+    end   
 
     # Returns +true+ if the record is persisted, i.e. it's not a new record and it was not destroyed
     def persisted?

--- a/lib/active_graph/shared/persistence.rb
+++ b/lib/active_graph/shared/persistence.rb
@@ -110,11 +110,11 @@ module ActiveGraph::Shared
       current_time = Time.now
       changes = {}
       attributes.each do |column|
-        column = column.to_s       
+        column = column.to_s
         changes[column] = write_attribute(column, current_time) if respond_to?((column + '=').to_sym)
       end
       save!
-    end   
+    end
 
     # Returns +true+ if the record is persisted, i.e. it's not a new record and it was not destroyed
     def persisted?


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * Implementing similar `touch` functionality to [ActiveRecord ](https://apidock.com/rails/ActiveRecord/Timestamp/touch)
 * Allows specifying column(s) to touch in addition to `updated_at`.
 * If no attributes are passed, it will simply touch `updated_at`

