### PR TITLE
Issue-1611 Fix in updating relations with ids

### DIFF
--- a/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
@@ -52,7 +52,7 @@ module ActiveGraph
           node_or_nodes = Array(node_or_nodes).map { |arg| arg.is_a?(ActiveGraph::Node) ? arg : @model.find(arg) }
           original_ids = self.pluck(:id)
           new_nodes = add_rels(node_or_nodes, original_ids)
-          delete_rels_for_nodes(original_ids, node_or_nodes)
+          delete_rels_for_nodes(original_ids, node_or_nodes.collect(&:id))
           new_nodes
         end
 
@@ -62,9 +62,8 @@ module ActiveGraph
           end.compact
         end
 
-        def delete_rels_for_nodes(original_ids, node_or_nodes)
-          new_ids = node_or_nodes.collect(&:id)
-          ids = original_ids.collect { |id| id unless new_ids.include?(id) }
+        def delete_rels_for_nodes(original_ids, new_ids)
+          ids = original_ids.select { |id| !new_ids.include?(id) }
           return unless ids.present?
           if association.dependent
             start_object.public_send("dependent_#{association.dependent}_callback", association, ids)

--- a/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
@@ -59,7 +59,8 @@ module ActiveGraph
         def idify_hash(args)
           Array(args).reject(&:blank?).flatten.each_with_object({}).with_index do |(arg, hash), inx|
             if arg.is_a?(Integer) || arg.is_a?(String)
-              hash[arg.to_i] = @model.find(arg)
+              key = arg.try(:match?, /\A\d+\z/) ? arg.to_i : arg
+              hash[key] = @model.find(arg)
             else
               key = arg.persisted? ? arg.id : "tmp_#{inx}"
               hash[key] = arg

--- a/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
@@ -49,32 +49,22 @@ module ActiveGraph
         # Deletes the relationships between all nodes for the last step in the QueryProxy chain and replaces them with relationships to the given nodes.
         # Executed in the database, callbacks will not be run.
         def replace_with(node_or_nodes)
-          node_hash = idify_hash(node_or_nodes)
+          node_or_nodes = Array(node_or_nodes).map { |arg| arg.is_a?(ActiveGraph::Node) ? arg : @model.find(arg) }
           original_ids = self.pluck(:id)
-          new_nodes = add_rels(node_hash, original_ids)
-          delete_rels_for_nodes(original_ids - node_hash.keys)
-          new_nodes | node_hash.values
+          new_nodes = add_rels(node_or_nodes, original_ids)
+          delete_rels_for_nodes(original_ids, node_or_nodes)
+          new_nodes
         end
 
-        def idify_hash(args)
-          Array(args).reject(&:blank?).flatten.each_with_object({}).with_index do |(arg, hash), inx|
-            if arg.is_a?(Integer) || arg.is_a?(String)
-              key = arg.try(:match?, /\A\d+\z/) ? arg.to_i : arg
-              hash[key] = @model.find(arg)
-            else
-              key = arg.persisted? ? arg.id : "tmp_#{inx}"
-              hash[key] = arg
-            end
-          end
-        end
-
-        def add_rels(node_hash, original_ids)
-          (node_hash.keys - original_ids).map do |id|
-            node_hash[id] if _create_relation_or_defer(node_hash[id])
+        def add_rels(node_or_nodes, original_ids)
+          node_or_nodes.map do |obj|
+            obj if original_ids.include?(obj.id) || _create_relation_or_defer(obj)
           end.compact
         end
 
-        def delete_rels_for_nodes(ids)
+        def delete_rels_for_nodes(original_ids, node_or_nodes)
+          new_ids = node_or_nodes.collect(&:id)
+          ids = original_ids.collect { |id| id unless new_ids.include?(id) }
           return unless ids.present?
           if association.dependent
             start_object.public_send("dependent_#{association.dependent}_callback", association, ids)

--- a/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/active_graph/node/query/query_proxy_methods_of_mass_updating.rb
@@ -51,9 +51,8 @@ module ActiveGraph
         def replace_with(node_or_nodes)
           node_or_nodes = Array(node_or_nodes).map { |arg| arg.is_a?(ActiveGraph::Node) ? arg : @model.find(arg) }
           original_ids = self.pluck(:id)
-          new_nodes = add_rels(node_or_nodes, original_ids)
           delete_rels_for_nodes(original_ids, node_or_nodes.collect(&:id))
-          new_nodes
+          add_rels(node_or_nodes, original_ids)
         end
 
         def add_rels(node_or_nodes, original_ids)

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -73,7 +73,9 @@ describe 'Association Proxy' do
     it 'does not recreate relatioship for existing relationships' do
       rel_id = science.exams_given.where(id: science_exam.id).rel.id
       science.exams_given = [science_exam]
-      expect(science.exams_given.rel.id).to eq(rel_id)
+      expect(Lesson.find(science.id).exams_given.rel.id).to eq(rel_id)
+      science.exams_given_ids = [science_exam.id]
+      expect(Lesson.find(science.id).exams_given.rel.id).to eq(rel_id)
     end
 
     it 'Should only make one query per association' do


### PR DESCRIPTION
Fixes #1611 

This pull introduces/changes:
 * The way we get what relations to delete on update of relationships
  In case there was a string ID property, the `to_i` on passed id parameter would cause it be inconsistent with IDs of existing relations and we would end up with deleting all existing relations.



