### PR TITLE
Don't use local path for the activegraph gem

### DIFF
--- a/docs/activegraph.rb
+++ b/docs/activegraph.rb
@@ -1,6 +1,6 @@
 # Usage: rails new myapp -m activegraph.rb
 
-gem 'activegraph', path: '~/mck/activegraph'
+gem 'activegraph'
 gem 'neo4j-ruby-driver'
 
 gem_group :development do


### PR DESCRIPTION
This is referenced in the [official installation documentation](https://neo4jrb.readthedocs.io/en/stable/Setup.html#generating-a-new-app). It should not assume that there is any gems installed in local paths.

Alternatively, the `-B` option should be added to the documentation, and information added there as well about how to fix the Gemfile befire running `bundle install`. 