### PR TITLE
Prevent after_commit from being called multiple times

### DIFF
--- a/lib/active_graph/transaction.rb
+++ b/lib/active_graph/transaction.rb
@@ -6,6 +6,9 @@ module ActiveGraph
     end
 
     def close
+      return if @closed
+      @closed = true
+
       success
       super
       after_commit_registry.each(&:call) unless @failure

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,10 +1,9 @@
 ## Configuration
 
-The specs are configured to run against `http://localhost:7474` by default. In order to change this in your local setup you can set the `NEO4J_URL` environment variable on your system to suit your needs.
+The specs are configured to run against `bolt://localhost:6998` by default. In order to change this in your local setup you can set the `NEO4J_URL` environment variable on your system to suit your needs.
 
 To make this easier, the neo4j spec suite allows you to add a `.env` file locally to configure this. For example, to set the `NEO4J_URL` you simply need to add a `.env` file that looks like this:
 
 ```
-NEO4J_URL=http://localhost:7475
+NEO4J_URL=bolt://localhost:7687
 ```
-

--- a/spec/active_graph/base_spec.rb
+++ b/spec/active_graph/base_spec.rb
@@ -135,47 +135,47 @@ describe ActiveGraph::Base do
 
     describe 'after_commit hook' do
       it 'gets called when the root transaction is closed' do
-        data = false
+        data = 0
         expect do
           subject.transaction do |tx1|
             subject.transaction do |tx2|
               subject.transaction do |tx3|
-                tx3.after_commit { data = true }
+                tx3.after_commit { data += 1 }
               end
             end
           end
-        end.to change { data }.to(true)
-        expect(data).to be_truthy
+        end.to change { data }.to(1)
+        expect(data).to eq(1)
       end
 
       it 'is ignored when the root transaction fails' do
-        data = false
+        data = 0
         expect do
           subject.transaction do |tx1|
             subject.transaction do |tx2|
               subject.transaction do |tx3|
-                tx3.after_commit { data = true }
+                tx3.after_commit { data += 1 }
               end
             end
             tx1.failure
           end
         end.not_to change { data }
-        expect(data).to be_falsey
+        expect(data).to eq(0)
       end
 
       it 'is ignored when a child transaction fails' do
-        data = false
+        data = 0
         expect do
           subject.transaction do |tx1|
             subject.transaction do |tx2|
               subject.transaction do |tx3|
-                tx3.after_commit { data = true }
+                tx3.after_commit { data += 1 }
                 tx3.failure
               end
             end
           end
         end.not_to change { data }
-        expect(data).to be_falsey
+        expect(data).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Ran into this while upgrading from neo4jrb 9 to activegraph. Our rails model test detected that `after_commit` hooks were being called multiple times. Something like this failed:

```
it "schedules do not disturb after the flag is changed" do
      expect(@user).to receive(:schedule_notification)

      @user.update_attributes(
        pending_notification: true
      )
end
```

where our User model had:

```
  after_update_commit do
    self.schedule_notification
  end
```

Our test failed claiming that `schedule_notification` was being called twice, and I went on to do some logging in `activegraph` to find that there was no guard against multiple `close` calls on a transaction, and `auto_closable` is causing `close` to be called both as part of successfully running the transaction and as part of auto-closing.

This pull introduces/changes:
 * Prevent erroneous calls to `after_commit` multiple times when a single transaction is closing
 * Prevent unnecessary calls, which add overhead, to other `close` functions including the `super` method from `neo4j-ruby-driver`
* Minor fix to README, which tripped me up, because it does not reflect what the port that `set_default_driver` is acutally attempting to use
