### PR TITLE
Remove unused exception class

### DIFF
--- a/lib/active_graph/core/connection_failed_error.rb
+++ b/lib/active_graph/core/connection_failed_error.rb
@@ -1,6 +1,0 @@
-module ActiveGraph
-  module Core
-    class ConnectionFailedError < StandardError;
-    end
-  end
-end


### PR DESCRIPTION
This appears to be unused. We had some code that handled `ConnectionFailedError` in `neoj4rb` 9, and that code was throwing `uninitialized constant ActiveGraph::Core::ConnectionFailedError`. While `ActiveGraph::Core::ConnectionFailedError` was actually written, it was never loaded and the code makes no reference to it.

I expect the test suite to prove out that this file has no effect on the codebase.