### PR TITLE
Wrap neo4j driver exceptions in ActiveGraph::Core::CypherError family

### DIFF
--- a/lib/active_graph/base.rb
+++ b/lib/active_graph/base.rb
@@ -33,6 +33,8 @@ module ActiveGraph
         transaction do
           super(*args)
         end
+      rescue Neo4j::Driver::Exceptions::ClientException => e
+        raise ActiveGraph::Core::CypherError.new_from(e.code, e.message, e.backtrace)
       end
 
       # Should support setting driver via config options


### PR DESCRIPTION
This is a straw man solution for #1639

I do not expect this is ultimately how we want to solve it, but rather, opening this PR as an example that satisfies the tests in my application (which are looking for `ActiveGraph:Core::SchemaErrors::ConstraintValidationFailedError`)

If you can give me instructions on where to make the proper fix and what you'd like to see in terms of testing, I can fix up this PR.