### PR TITLE
Fix caching bugs in rails reloading

### DIFF
--- a/lib/active_graph/node/labels/reloading.rb
+++ b/lib/active_graph/node/labels/reloading.rb
@@ -4,15 +4,32 @@ module ActiveGraph::Node::Labels
 
     MODELS_TO_RELOAD = []
 
+    def self.prepare_for_unload!
+      # clear label caches
+      ActiveGraph::Node::Labels.clear_wrapped_models
+
+      WRAPPED_CLASSES.each do |c|
+        # request refresh on any association proxies
+        # that survive the reload
+        c.associations.each_value(&:queue_model_refresh!)
+
+        # save the class name to be reloaded later
+        MODELS_TO_RELOAD << c.name
+      end
+      WRAPPED_CLASSES.clear
+    end
+
     def self.reload_models!
       MODELS_TO_RELOAD.each(&:constantize)
       MODELS_TO_RELOAD.clear
     end
 
     module ClassMethods
+      # NOTE: it seems that this method is not always called
+      # by ActiveSupport, even though it probably should be.
       def before_remove_const
         associations.each_value(&:queue_model_refresh!)
-        MODELS_FOR_LABELS_CACHE.clear
+        ActiveGraph::Node::Labels.clear_wrapped_models
         WRAPPED_CLASSES.each { |c| MODELS_TO_RELOAD << c.name }
         WRAPPED_CLASSES.clear
       end

--- a/lib/active_graph/railtie.rb
+++ b/lib/active_graph/railtie.rb
@@ -18,7 +18,12 @@ module ActiveGraph
       ActiveSupport::Reloader.to_prepare do
         ActiveGraph::Node::Labels::Reloading.reload_models!
       end
+
+      ActiveSupport::Reloader.before_class_unload do
+        ActiveGraph::Node::Labels::Reloading.prepare_for_unload!
+      end
     elsif const_defined?(:ActionDispatch)
+      # NOTE: ActionDispatch::Reloader::to_prepare was removed after v5.0.0.1
       ActionDispatch::Reloader.to_prepare do
         ActiveGraph::Node::Labels::Reloading.reload_models!
       end


### PR DESCRIPTION
Add slightly more aggressive clearing of caches during rails reloads.

Fixes query results being wrapped in stale classes after a reload.

This pull introduces/changes:
 * adds ActiveGraph::Node::Labels::Reloading.prepare_for_unload! method
 * call to prepare_for_unload! in an ActiveSupport::Reloader.before_class_unload callback
 * document use of deprecated/removed method
 * replace MODELS_FOR_LABELS_CACHE.clear with ActiveGraph::Node::Labels.clear_wrapped_models,
    which clears that cache as well as another one!
