### PR TITLE
Fixing relationship length in query proxy eagerloading module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [11.0.1] 2021-07-14
+
+- It changes the relationship length assignment in query proxy eagerloading module to be consistent with query proxy relationship length syntax.
+
 ## [11.0.0] 2021-06-25
 
 ## Added

--- a/lib/active_graph/node/query/query_proxy_eager_loading.rb
+++ b/lib/active_graph/node/query/query_proxy_eager_loading.rb
@@ -157,7 +157,7 @@ module ActiveGraph
         end
 
         def relationship_part(association, path_name, rel_length)
-          rel_name = rel_length ? nil : escape("#{path_name}_rel")
+          rel_name = escape("#{path_name}_rel") unless rel_length
           "#{association.arrow_cypher(rel_name, {}, false, false, rel_length)}(#{escape(path_name)})"
         end
 

--- a/lib/active_graph/node/query/query_proxy_eager_loading.rb
+++ b/lib/active_graph/node/query/query_proxy_eager_loading.rb
@@ -157,14 +157,8 @@ module ActiveGraph
         end
 
         def relationship_part(association, path_name, rel_length)
-          if rel_length
-            rel_name = nil
-            length = {max: rel_length}
-          else
-            rel_name = escape("#{path_name}_rel")
-            length = nil
-          end
-          "#{association.arrow_cypher(rel_name, {}, false, false, length)}(#{escape(path_name)})"
+          rel_name = rel_length ?  nil : escape("#{path_name}_rel")
+          "#{association.arrow_cypher(rel_name, {}, false, false, rel_length)}(#{escape(path_name)})"
         end
 
         def chain

--- a/lib/active_graph/node/query/query_proxy_eager_loading.rb
+++ b/lib/active_graph/node/query/query_proxy_eager_loading.rb
@@ -68,7 +68,7 @@ module ActiveGraph
 
         def init_associations(node, element)
           element.each_key { |key| node.association_proxy(key).init_cache }
-          node.association_proxy(element.name).init_cache if element.rel_length == ''
+          node.association_proxy(element.name).init_cache if element.rel_length && element.rel_length[:max] == ''
         end
 
         def cache_and_init(node, element)
@@ -157,7 +157,7 @@ module ActiveGraph
         end
 
         def relationship_part(association, path_name, rel_length)
-          rel_name = rel_length ?  nil : escape("#{path_name}_rel")
+          rel_name = rel_length ? nil : escape("#{path_name}_rel")
           "#{association.arrow_cypher(rel_name, {}, false, false, rel_length)}(#{escape(path_name)})"
         end
 

--- a/lib/active_graph/node/query/query_proxy_eager_loading/association_tree.rb
+++ b/lib/active_graph/node/query/query_proxy_eager_loading/association_tree.rb
@@ -58,6 +58,7 @@ module ActiveGraph
           def process_string(str)
             head, rest = str.split('.', 2)
             k, length = head.split('*', -2)
+            length = { max: length } if length
             add_nested(k.to_sym, rest, length)
           end
 

--- a/lib/active_graph/node/query/query_proxy_eager_loading/association_tree.rb
+++ b/lib/active_graph/node/query/query_proxy_eager_loading/association_tree.rb
@@ -58,7 +58,7 @@ module ActiveGraph
           def process_string(str)
             head, rest = str.split('.', 2)
             k, length = head.split('*', -2)
-            length = { max: length } if length
+            length = {max: length} if length
             add_nested(k.to_sym, rest, length)
           end
 


### PR DESCRIPTION

This pull introduces/changes:
 *  It changes the relationship length assignment in query proxy eagerloading module to be consistent with query proxy relationship length syntax.



