### PR TITLE
Bring Dockerfile current with "activegraph" naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM jruby:latest
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
@@ -6,17 +6,15 @@ RUN apt-get update && \
     apt-get clean -y
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-RUN mkdir /usr/src/app
 WORKDIR /usr/src/app/
 
-COPY Gemfile* ./
-COPY neo4j.gemspec ./
-COPY lib/neo4j/version.rb ./lib/neo4j/
-RUN bundle
+RUN gem install bundler -v '~> 2'
+COPY Gemfile* activegraph.gemspec ./
+COPY lib/active_graph/version.rb ./lib/active_graph/
+RUN bundle install
 
 ADD . ./
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
-


### PR DESCRIPTION
Bring the Dockerfile up to date with the current structure of the gem.

1. Update gemfile directory paths
2. Follow github actions test and install bundler to latest 2.x version

```
$ docker build -t activegraph-gem .
```