### PR TITLE
Branch 10 copy of Update Dockerfile with current "activegraph" naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,20 @@ RUN apt-get update && \
     apt-get clean -y
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-RUN mkdir /usr/src/app
 WORKDIR /usr/src/app/
 
-COPY Gemfile* ./
-COPY neo4j.gemspec ./
-COPY lib/neo4j/version.rb ./lib/neo4j/
-RUN bundle
+# Seabolt install. Needed for bolt driver interface
+ADD https://github.com/neo4j-drivers/seabolt/releases/download/v1.7.4/seabolt-1.7.4-Linux-ubuntu-18.04.deb /usr
+RUN dpkg -i /usr/seabolt-1.7.4-Linux-ubuntu-18.04.deb
+RUN rm /usr/seabolt-1.7.4-Linux-ubuntu-18.04.deb
+
+RUN gem install bundler -v '~> 2'
+COPY Gemfile* activegraph.gemspec ./
+COPY lib/active_graph/version.rb ./lib/active_graph/
+RUN bundle install
 
 ADD . ./
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
-


### PR DESCRIPTION
Copy of https://github.com/neo4jrb/activegraph/pull/1658 onto branch `10`

> Bring the Dockerfile up to date with the current structure of the gem.
>
> 1. Update gemfile directory paths
> 2. Follow github actions test and install bundler to latest 2.x version
> 3. Install Seabolt driver for Bolt adapter connected unit tests
>
> `$ docker build -t activegraph-gem .`