### PR TITLE
Match has_one direction before deleting rel

### DIFF
--- a/lib/active_graph/node/has_n.rb
+++ b/lib/active_graph/node/has_n.rb
@@ -253,8 +253,10 @@ module ActiveGraph::Node
 
     def relationship_corresponding_rel(relationship, direction, target_class)
       self.class.associations.find do |_key, assoc|
-        assoc.relationship_class_name == relationship.class.name ||
-          (assoc.relationship_type == relationship.type.to_sym && assoc.target_class == target_class && assoc.direction == direction)
+        assoc.direction == direction && (
+          assoc.relationship_class_name == relationship.class.name ||
+          (assoc.relationship_type == relationship.type.to_sym && assoc.target_class == target_class)
+        )
       end
     end
 

--- a/spec/e2e/relationship_spec.rb
+++ b/spec/e2e/relationship_spec.rb
@@ -610,43 +610,39 @@ describe 'Relationship' do
 
     after(:each) { [@gen0, @gen1, @gen2].compact.each(&:destroy) }
 
-    shared_examples_for :creating_gen2 do
-      it "creates (gen1)-->(gen0)" do
-        @gen1 = NodeClass.create parent: @gen0
-
-        expect(@gen1.parent.id).to eq @gen0.id
-
-        expect(@gen0.children.count).to eq 1
-        expect(@gen0.children.first.id).to eq @gen1.id
-      end
-
-      context "given (gen1)-->(gen0)" do
-        before(:each) { @gen1 = NodeClass.create parent: @gen0 }
-
-        describe "#create (gen2)-->(gen1)" do
-          it "adds a new node and relationsihp without affecting (gen1)-->(gen0)" do
-            @gen2 = NodeClass.create parent: @gen1
-
-            expect(@gen2.parent.id).to eq @gen1.id
-
-            expect(@gen1.children.count).to eq 1
-            expect(@gen1.children.first.id).to eq @gen2.id
-
-            expect(@gen1.parent).to(be_present, "gen1 lost its parent")
-            expect(@gen1.parent.id).to eq @gen0.id
-
-            expect(@gen0.children.count).to eq 1
-            expect(@gen0.children.first.id).to eq @gen1.id
-          end
-        end
-      end
-    end
-
     %i(all none).each do |uniqueness|
       context "with creates_unique(:#{uniqueness})" do
         before(:each) { IsParentOf.creates_unique uniqueness }
 
-        include_examples :creating_gen2
+        it "creates (gen1)-->(gen0)" do
+          @gen1 = NodeClass.create parent: @gen0
+
+          expect(@gen1.parent.id).to eq @gen0.id
+
+          expect(@gen0.children.count).to eq 1
+          expect(@gen0.children.first.id).to eq @gen1.id
+        end
+
+        context "given (gen1)-->(gen0)" do
+          before(:each) { @gen1 = NodeClass.create parent: @gen0 }
+
+          describe "#create (gen2)-->(gen1)" do
+            it "adds a new node and relationsihp without affecting (gen1)-->(gen0)" do
+              @gen2 = NodeClass.create parent: @gen1
+
+              expect(@gen2.parent.id).to eq @gen1.id
+
+              expect(@gen1.children.count).to eq 1
+              expect(@gen1.children.first.id).to eq @gen2.id
+
+              expect(@gen1.parent).to(be_present, "gen1 lost its parent")
+              expect(@gen1.parent.id).to eq @gen0.id
+
+              expect(@gen0.children.count).to eq 1
+              expect(@gen0.children.first.id).to eq @gen1.id
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1650

When `relationship_corresponding_rel` matches on the rel class name,
it stops on the first match, ignoring the `direction` parameter.

When `target_class` represents the `to_node`, direction is `:in`.

When the relationship is a `has_one`/`has_many` between a pair
of nodes of the same class, the match could find and return
the `to_node`'s `:out` association first, causing
`delete_reverse_has_one_relationship` to delete it.

Checking the direction first prevents that.

Sadly, I worked through #1660 before seeing #1650 and that I had reached the same basic conclusion, only factoring the fix slightly differently than the OP proposed.

### Test runs
I added 4 examples—2 simply show that the 'setup' in the 'real' examples works as expected. The other 2 (really the same example but under both `creates_unique :all` and `creates_unique :none`) show the problem.

#### Before
`1907 examples, 0 failures, 5 pending`

#### After
##### Without the fix
```
[...]
1) between nodes of the same class with creates_unique(:all) given (gen1)-->(gen0) #create (gen2)-->(gen1) adds a new node and relationsihp without affecting (gen1)-->(gen0)
     Failure/Error: expect(@gen1.parent).to(be_present, "gen1 lost its parent")
       gen1 lost its parent
     Shared Example Group: :creating_gen2 called from ./spec/e2e/relationship_spec.rb:650
     # ./spec/e2e/relationship_spec.rb:636:in `block (5 levels) in <top (required)>'

  2) between nodes of the same class with creates_unique(:none) given (gen1)-->(gen0) #create (gen2)-->(gen1) adds a new node and relationsihp without affecting (gen1)-->(gen0)
     Failure/Error: expect(@gen1.parent).to(be_present, "gen1 lost its parent")
       gen1 lost its parent
     Shared Example Group: :creating_gen2 called from ./spec/e2e/relationship_spec.rb:650
     # ./spec/e2e/relationship_spec.rb:636:in `block (5 levels) in <top (required)>'

1911 examples, 2 failures, 5 pending
```
##### With the fix
`1911 examples, 0 failures, 5 pending`
