### PR TITLE
fix: Update ActiveGraph::Core::Schema to to handle labelless indexes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ 2.5, 3.0, 3.1, jruby-9.3.3.0 ]
-        neo4j: [ 3.5.30, 4.0.12, 4.4.0 ]
+        neo4j: [ 4.4.0 ]
         driver: [ ffi ]
         include:
           - ruby: jruby-9.3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ 2.5, 3.0, 3.1, jruby-9.3.3.0 ]
-        neo4j: [ 3.5.30, 4.0.12 ]
+        neo4j: [ 3.5.30, 4.0.12, 4.4.0 ]
         driver: [ ffi ]
         include:
           - ruby: jruby-9.3.3.0

--- a/lib/active_graph/version.rb
+++ b/lib/active_graph/version.rb
@@ -1,3 +1,3 @@
 module ActiveGraph
-  VERSION = '10.1.1'
+  VERSION = '10.1.2'
 end


### PR DESCRIPTION
When connecting to Neo4j Aura some inexes have labelsOrTypes set to `[]`.
This causes https://github.com/neo4jrb/activegraph/blob/master/lib/active_graph/core/schema.rb#L49 to throw `NoMethodError: undefined method` error.

This pull introduces/changes:
 * Updates ActiveGraph::Core::Schema#label not to throw an error when `row[:labelsOrTypes]` is an empty array. It returns `row["name"]` in such case.



