### PR TITLE
[fix] Move ActiveGraph::Migrations runner into separated transaction

### DIFF
--- a/lib/active_graph/tasks/migration.rake
+++ b/lib/active_graph/tasks/migration.rake
@@ -91,6 +91,9 @@ COMMENT
 
       ActiveGraph::Base.transaction do
         runner = ActiveGraph::Migrations::Runner.new
+      end
+
+      ActiveGraph::Base.transaction do
         runner.mark_versions_as_complete(schema_data[:versions]) # Run in test mode?
       end
     end


### PR DESCRIPTION
This solves problem of running rake `neo4j:schema:load` task. The main problems was in fact that in one transaction we tried to change schema (adding new constraint) and modify data (add new migrations).

This pull introduces/changes:
 * Provides two separated (implicit) transactions instead of one for introduction Migrations runner and loading migrations itself.


Link to discussion from gitter: https://gitter.im/neo4jrb/neo4j?at=630c77a59d3c186299d5e13c
