### PR TITLE
Fixes lost @rel_var when branching QueryProxy

### DIFF
--- a/lib/active_graph/node/has_n.rb
+++ b/lib/active_graph/node/has_n.rb
@@ -110,11 +110,8 @@ module ActiveGraph::Node
       end
 
       def add_to_cache(object, rel = nil)
-        if rel
-          (@cached_rels ||= []) << rel
-        else
-          (@cached_result ||= []).tap { |results| results << object unless results.include?(object) }
-        end
+        (@cached_rels ||= []) << rel if rel
+        (@cached_result ||= []).tap { |results| results << object if object && !results.include?(object) }
       end
 
       def rels

--- a/lib/active_graph/node/has_n.rb
+++ b/lib/active_graph/node/has_n.rb
@@ -38,7 +38,7 @@ module ActiveGraph::Node
         return [] unless node || rel
 
         if node && rel
-          pairs_with_deferred
+          result_nodes.zip(rels)
         elsif node
           result_nodes
         else
@@ -110,12 +110,15 @@ module ActiveGraph::Node
       end
 
       def add_to_cache(object, rel = nil)
-        (@cached_rels ||= []) << rel if rel
-        (@cached_result ||= []).tap { |results| results << object unless results.include?(object) }
+        if rel
+          (@cached_rels ||= []) << rel
+        else
+          (@cached_result ||= []).tap { |results| results << object unless results.include?(object) }
+        end
       end
 
       def rels
-        @cached_rels || super
+        @cached_rels || super.tap { |rels| rels.each { |rel| add_to_cache(nil, rel)  } }
       end
 
       def cache_query_proxy_result

--- a/lib/active_graph/node/has_n.rb
+++ b/lib/active_graph/node/has_n.rb
@@ -47,7 +47,7 @@ module ActiveGraph::Node
       end
 
       def each_rel(&block)
-        each(false, true, &block)
+        rels.each(&block)
       end
 
       # .count always hits the database
@@ -170,10 +170,6 @@ module ActiveGraph::Node
       end
 
       private
-
-      def pairs_with_deferred
-        @query_proxy.to_a(true, true) + @deferred_objects.map { |obj| [obj] }
-      end
 
       def map_results_as_nodes(result)
         result.map do |object|

--- a/lib/active_graph/node/has_n.rb
+++ b/lib/active_graph/node/has_n.rb
@@ -34,12 +34,20 @@ module ActiveGraph::Node
 
       include Enumerable
 
-      def each(&block)
-        result_nodes.each(&block)
+      def each(node = true, rel = nil, &block)
+        return [] unless node || rel
+
+        if node && rel
+          pairs_with_deferred
+        elsif node
+          result_nodes
+        else
+          rels
+        end.each(&block)
       end
 
       def each_rel(&block)
-        rels.each(&block)
+        each(false, true, &block)
       end
 
       # .count always hits the database
@@ -162,6 +170,10 @@ module ActiveGraph::Node
       end
 
       private
+
+      def pairs_with_deferred
+        @query_proxy.to_a(true, true) + @deferred_objects.map { |obj| [obj] }
+      end
 
       def map_results_as_nodes(result)
         result.map do |object|

--- a/lib/active_graph/node/query/query_proxy_methods.rb
+++ b/lib/active_graph/node/query/query_proxy_methods.rb
@@ -48,7 +48,7 @@ module ActiveGraph
         end
 
         def propagate_context(query_proxy)
-          query_proxy.instance_variable_set(:@distinct, @distinct)
+          [:@distinct, :@rel_var].each { |var| query_proxy.instance_variable_set(var, instance_variable_get(var)) }
         end
 
         # @return [Integer] number of nodes of this class

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -309,6 +309,15 @@ describe 'Association Proxy' do
         expect(lessons.to_a(true, false)).to eq(lessons.to_a)
         expect(lessons.to_a(true, true).flat_map { |pair| pair.map(&:class) }.uniq).to eq([Lesson, LessonEnrollment])
         expect(lessons.to_a(false, nil)).to eq([])
+        expect(lessons.to_a(false, true)).to eq(lessons.rels)
+      end
+    end
+
+    describe '#rels' do
+      it 'caches results for consecutive calls' do
+        expect_queries(1) do
+          2.times { billy.lessons.rels }
+        end
       end
     end
 

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -303,6 +303,12 @@ describe 'Association Proxy' do
         expect(billy.lessons(:l).pluck(:l)).not_to include(nil)
         expect(billy.lessons(:l).method(:pluck).source_location.first).not_to include('active_support')
       end
+
+      it 'allows to call .to_a with arguments' do
+        expect(billy.lessons.to_a(true, false)).to eq(billy.lessons.to_a)
+        expect(billy.lessons.to_a(true, true).flat_map { |pair| pair.map(&:class) }.uniq).to eq([Lesson, LessonEnrollment])
+        expect(billy.lessons.to_a(false, nil)).to eq([])
+      end
     end
 
     describe '#inspect' do

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -298,6 +298,7 @@ describe 'Association Proxy' do
 
     context 'when requiring "active_support/core_ext/enumerable"' do
       require 'active_support/core_ext/enumerable'
+      let(:lessons) { billy.lessons }
 
       it 'uses the correct `pluck` method' do
         expect(billy.lessons(:l).pluck(:l)).not_to include(nil)
@@ -305,9 +306,9 @@ describe 'Association Proxy' do
       end
 
       it 'allows to call .to_a with arguments' do
-        expect(billy.lessons.to_a(true, false)).to eq(billy.lessons.to_a)
-        expect(billy.lessons.to_a(true, true).flat_map { |pair| pair.map(&:class) }.uniq).to eq([Lesson, LessonEnrollment])
-        expect(billy.lessons.to_a(false, nil)).to eq([])
+        expect(lessons.to_a(true, false)).to eq(lessons.to_a)
+        expect(lessons.to_a(true, true).flat_map { |pair| pair.map(&:class) }.uniq).to eq([Lesson, LessonEnrollment])
+        expect(lessons.to_a(false, nil)).to eq([])
       end
     end
 

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -822,8 +822,12 @@ describe 'query_proxy_methods' do
       expect(@john.lessons.branch { teachers }).to be_a(ActiveGraph::Node::Query::QueryProxy)
     end
 
-    it 'keeps identity to the external chain' do
+    it 'keeps identity to the external chain - node' do
       expect(@john.lessons(:l).branch { teachers(:t) }.identity).to eq(:l)
+    end
+
+    it 'keeps identity to the external chain - rel' do
+      expect(@history.students(:student, :enrolledIn).branch { all }.rel_var).to eq(:enrolledIn)
     end
 
     it 'queries lessions' do


### PR DESCRIPTION
Fixes #1676

This pull introduces/changes:
 * propagates relationship alias when branching.  
 * implements #to_a with parameters on AssociationProxy 
 



