### PR TITLE
Add psych as dependency and fix schema load on psych >= 4.0.1

### DIFF
--- a/activegraph.gemspec
+++ b/activegraph.gemspec
@@ -36,6 +36,7 @@ DESCRIPTION
   s.add_dependency('neo4j-ruby-driver', '>= 4.4.1')
   s.add_dependency('orm_adapter', '~> 0.5.0')
   s.add_dependency('sorted_set')
+  s.add_dependency('psych', '>= 4.0.1')
   s.add_development_dependency('guard')
   s.add_development_dependency('guard-rspec')
   s.add_development_dependency('guard-rubocop')

--- a/activegraph.gemspec
+++ b/activegraph.gemspec
@@ -36,7 +36,6 @@ DESCRIPTION
   s.add_dependency('neo4j-ruby-driver', '>= 4.4.1')
   s.add_dependency('orm_adapter', '~> 0.5.0')
   s.add_dependency('sorted_set')
-  s.add_dependency('psych', '>= 4.0.1')
   s.add_development_dependency('guard')
   s.add_development_dependency('guard-rspec')
   s.add_development_dependency('guard-rubocop')

--- a/lib/active_graph/tasks/migration.rake
+++ b/lib/active_graph/tasks/migration.rake
@@ -83,7 +83,7 @@ COMMENT
 
       args.with_defaults(remove_missing: false)
 
-      schema_data = YAML.safe_load(File.read(SCHEMA_YAML_PATH), [Symbol])
+      schema_data = YAML.safe_load(File.read(SCHEMA_YAML_PATH), permitted_classes: [Symbol])
 
       ActiveGraph::Base.subscribe_to_query(&method(:puts))
 

--- a/lib/active_graph/tasks/migration.rake
+++ b/lib/active_graph/tasks/migration.rake
@@ -83,7 +83,11 @@ COMMENT
 
       args.with_defaults(remove_missing: false)
 
-      schema_data = YAML.safe_load(File.read(SCHEMA_YAML_PATH), permitted_classes: [Symbol])
+      schema_data = if Gem::Requirement.new(">= 4.0.1") =~ Gem::Version.new(Psych::VERSION)
+        YAML.safe_load(File.read(SCHEMA_YAML_PATH), permitted_classes: [Symbol])
+      else
+        YAML.safe_load(File.read(SCHEMA_YAML_PATH), [Symbol])
+      end
 
       ActiveGraph::Base.subscribe_to_query(&method(:puts))
 


### PR DESCRIPTION
Add psych as dependency and fix schema load on psych >= 4.0.1, because from version 4 psych, has changed the API for load_safe.

Resolves #1684




