### PR TITLE
Failing spec to ID scope wrong alias issue

### DIFF
--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -855,6 +855,21 @@ describe 'Query API' do
         expect(lesson.teachers.where(name: 'aoeuo').to_a).to be_empty
       end
     end
+
+    context 'when association used after identity-scope' do
+      subject { Level.experts.teachers }
+
+      before do
+        stub_node_class('Level') do
+          property :name
+          has_many :out, :teachers, model_class: 'Teacher', type: 'level'
+          scope :experts, -> { where("#{identity}.name = 'expert'") }
+        end
+      end
+      let!(:expert_level) { Level.create(name: 'expert', teachers: [mrjames]) }
+
+      it { is_expected.to contain_exactly mrjames }
+    end
   end
 
   describe 'batch finding' do


### PR DESCRIPTION
This pull request demonstrate the bug of an identiy-scope. when such scope is used along with association, it generates wrong cypher. The test example generates following cypher

```
Neo4j::Driver::Exceptions::ClientException:
       Variable `result_level2` not defined (line 1, column 30 (offset: 29))
       "MATCH (node2:`Level`) WHERE (result_level2.name = 'expert') MATCH (node2)-[rel1:`level`]->(result_teachers3:`Teacher`) RETURN result_teachers3"
```



